### PR TITLE
NWST-175: Add in wagtail-2fa

### DIFF
--- a/newstream/settings/base.py
+++ b/newstream/settings/base.py
@@ -104,6 +104,11 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.sites',
 
+    'wagtail_2fa',
+
+    'django_otp',
+    'django_otp.plugins.otp_totp',
+
     # newstream apps
     'pages',
     # 'search',
@@ -126,6 +131,8 @@ MIDDLEWARE = [
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 
     'newstream.view_middleware.DisableSocialLoginMiddleware',
+
+    'wagtail_2fa.middleware.VerifyUserMiddleware',
 ]
 
 ROOT_URLCONF = 'newstream.urls'

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ tablib==2.0.0
 Unidecode==1.1.1
 urllib3==1.25.10
 wagtail==2.9.3
+wagtail-2fa==1.4.2
 wagtail-autocomplete==0.6
 wagtail-modelchooser==2.3.3
 wagtail-modeltranslation==0.10.14


### PR DESCRIPTION
Tested this locally and it appears to work exactly as described. Adds on 2fa support for admin
users, and can be used to require 2FA for admin pages via settings param