### PR TITLE
NWST-232: Add language switcher back to frontend site

### DIFF
--- a/donations/email_functions.py
+++ b/donations/email_functions.py
@@ -38,7 +38,7 @@ def sendEmailNotificationsToDonor(user_email, subject, textStr, htmlStr):
 
 def sendEmailNotificationsToAdmins(site_settings, subject, textStr, htmlStr):
     # set default language for admins' emails
-    translation.activate(settings.LANGUAGE_CODE)
+    # translation.activate(settings.LANGUAGE_CODE)
 
     admin_list = [
         admin_email.email for admin_email in site_settings.admin_emails.all()]

--- a/email_campaigns/custom_classes.py
+++ b/email_campaigns/custom_classes.py
@@ -94,10 +94,10 @@ class SendCampaignView(InstanceSpecificView):
             self.mails_sent = 0
             self.refused_list = []
             for recipient, lang_pref in unique_list:
-                if lang_pref:
-                    translation.activate(lang_pref)
-                else:
-                    translation.activate(settings.LANGUAGE_CODE)
+                # if lang_pref:
+                #     translation.activate(lang_pref)
+                # else:
+                #     translation.activate(settings.LANGUAGE_CODE)
                 num = send_mail(template.subject, self.textAppendUnsubscribeLink(recipient, template.plain_text), model.from_address, [
                                 recipient], html_message=self.htmlAppendUnsubscribeLink(recipient, richtext(template.html_body)))
                 if num == 0:
@@ -105,10 +105,10 @@ class SendCampaignView(InstanceSpecificView):
                 self.mails_sent += num
 
             # reactivate original lang
-            if original_lang:
-                translation.activate(original_lang)
-            else:
-                translation.activate(settings.LANGUAGE_CODE)
+            # if original_lang:
+            #     translation.activate(original_lang)
+            # else:
+            #     translation.activate(settings.LANGUAGE_CODE)
 
             if self.mails_sent > 0:
                 model.sent = True

--- a/newstream/forms_signup.py
+++ b/newstream/forms_signup.py
@@ -56,8 +56,8 @@ class BaseSignupForm(forms.Form):
 
         # set language for email_confirmation_subject/message.txt
         # todo: translation: tested but email message does not seem to translate
-        if user.language_preference:
-            translation.activate(user.language_preference)
+        # if user.language_preference:
+        #     translation.activate(user.language_preference)
 
         # save to session to remember user's registration
         request.session['first_time_registration'] = True

--- a/newstream/templates/common/lang_switcher_body.html
+++ b/newstream/templates/common/lang_switcher_body.html
@@ -1,26 +1,23 @@
 {% load i18n common_tags wagtailcore_tags %}
 
+{% get_current_language as LANGUAGE_CODE %}
 <!-- this html must be wrapped by .dropdown-div-wrapper in parent file for the dropdown popup to work  -->
 <input type="checkbox" name="{{prefix}}_multilang-dropdown-toggle-checkbox"
     id="{{prefix}}_multilang-dropdown-toggle-checkbox" class="dropdown-toggle-checkbox">
 <label for="{{prefix}}_multilang-dropdown-toggle-checkbox" class="dropdown-toggle-label"></label>
-<span class="language-code">{{ request.LANGUAGE_CODE }}</span>
+<span class="language-code">{{ LANGUAGE_CODE }}</span>
 <span class="multilang-icon"></span>
 <div class="multilang-dropdown-menu dropdown-menu-popup flex flex-col items-stretch">
     <form action="{% url 'set_language' %}" method="post" id="{{prefix}}-switch-lang-form">
         {% csrf_token %}
-        <input name="next" type="hidden" value="{{ redirect_to }}">
-        <select name="language" class="language-switcher-select"
-                                onchange="document.getElementById('{{prefix}}-switch-lang-form').submit();">
-            {% get_current_language as LANGUAGE_CODE %}
-            {% get_available_languages as LANGUAGES %}
-            {% get_language_info_list for LANGUAGES as languages %}
-            {% for language in languages %}
-            <option value="{{ language.code }}" {% if language.code == LANGUAGE_CODE %} selected{% endif %}>
-                {{ language.name_local }} ({{ language.code }})
-            </option>
-            {% endfor %}
-        </select>
-        <input type="submit" value="Go" class="hidden">
+        <input name="next" type="hidden" value="{{ request.path|strip_lang:LANGUAGE_CODE }}">
+        {% get_available_languages as LANGUAGES %}
+        {% get_language_info_list for LANGUAGES as languages %}
+        {% for language in languages %}
+            {% if language.code != LANGUAGE_CODE %}
+            <button type="submit" name="language" value="{{ language.code }}">{{ language.name_local }}</button>
+            {% endif %}
+        {% endfor %}
+        <!-- <input type="submit" value="Go" class="hidden"> -->
     </form>
 </div>

--- a/newstream/templates/common/mobile_main_menu.html
+++ b/newstream/templates/common/mobile_main_menu.html
@@ -3,9 +3,7 @@
 <div id="newstream-mobile-mainmenu" class="bg-white flex flex-col items-stretch">
     <div class="btm-grey-border flex justify-between items-center py-6 px-8">
         <div class="multilang-dropdown-div flex items-center dropdown-div-wrapper">
-            <div class="hidden">
             {% include 'common/lang_switcher_body.html' with prefix='mobile' %}
-            </div>
         </div>
         <div id="close-nav-toggle" class="focus:outline-none cursor-pointer" onclick="toggleSidenav();">
             <span></span>

--- a/newstream/templates/header.html
+++ b/newstream/templates/header.html
@@ -36,7 +36,7 @@
             <a href="{% url 'account_login' %}{{ request.path|next_path_filter }}" class="mr-16 menu-item">Sign in</a>
             {% endif %}
             <a href="{% url 'donations:donate'%}" class="menu-item nav-donate-btn">Donate</a>
-            <div class="multilang-dropdown-div ml-6 hidden lg:hidden items-center dropdown-div-wrapper">
+            <div class="multilang-dropdown-div ml-6 hidden lg:flex items-center dropdown-div-wrapper">
                 {% include 'common/lang_switcher_body.html' with prefix='main' %}
             </div>
         </div>

--- a/newstream/templatetags/common_tags.py
+++ b/newstream/templatetags/common_tags.py
@@ -35,6 +35,11 @@ def get_attr(object, key):
     return getattr(object, key, '')
 
 
+@register.filter(name='strip_lang')
+def get_attr(current_url, current_lang):
+    return re.sub("^/%s/" % current_lang, "/", current_url)
+
+
 @register.simple_tag
 def site_url():
     """

--- a/newstream/views.py
+++ b/newstream/views.py
@@ -48,8 +48,8 @@ def personal_info(request):
             user.last_name = form.cleaned_data['last_name']
             user.opt_in_mailing_list = form.cleaned_data['opt_in_mailing_list']
             user.language_preference = form.cleaned_data['language_preference']
-            translation.activate(user.language_preference)
-            request.LANGUAGE_CODE = translation.get_language()
+            # translation.activate(user.language_preference)
+            # request.LANGUAGE_CODE = translation.get_language()
             user.metas = user_metas
             user.save()
             messages.add_message(request, messages.SUCCESS,

--- a/newstream_user/signals.py
+++ b/newstream_user/signals.py
@@ -8,17 +8,17 @@ from newstream.functions import trans_next_url
 from donations.email_functions import sendAccountCreatedNotifToAdmins
 
 
-@receiver(user_logged_in)
-def newstream_user_logged_in(sender, request, response, user, **kwargs):
-    # if 'user' in kwargs.keys() and 'request' in kwargs.keys() and 'response' in kwargs.keys():
-    # user = kwargs['user']
-    if user.language_preference:
-        user_language = user.language_preference
-        translation.activate(user_language)
-        request.LANGUAGE_CODE = translation.get_language()
-        response['Location'] = trans_next_url(response.url, user_language)
-        response.set_cookie(
-            settings.LANGUAGE_COOKIE_NAME, user_language)
+# @receiver(user_logged_in)
+# def newstream_user_logged_in(sender, request, response, user, **kwargs):
+#     # if 'user' in kwargs.keys() and 'request' in kwargs.keys() and 'response' in kwargs.keys():
+#     # user = kwargs['user']
+#     if user.language_preference:
+#         user_language = user.language_preference
+#         translation.activate(user_language)
+#         request.LANGUAGE_CODE = translation.get_language()
+#         response['Location'] = trans_next_url(response.url, user_language)
+#         response.set_cookie(
+#             settings.LANGUAGE_COOKIE_NAME, user_language)
 
 
 @receiver(user_signed_up)


### PR DESCRIPTION
- added back the previously hidden language switcher
- simplified the switcher dropdown to clickable alternate languages for better UX
- replaced the empty redirect_to variable to the current url without language prefix
- and commented all translation.activate usages since language preference is still not in use(which also fixes language silently switches back to english during a zh-hant donation due to the translation.activate call in sendEmailNotificationsToAdmins)