### PR TITLE
NWST-233: Fix Preview Url on social media(FB) showing "301 Permanently Redirected" instead of Preview Image and Title

### DIFF
--- a/newstream/functions.py
+++ b/newstream/functions.py
@@ -94,9 +94,10 @@ def get_default_site():
 def get_site_url():
     """
     Returns the site's hostname with the correct protocol prefixed
+    the HTTPS environment variable is being set to 'on' in wsgi.py
     """
     default_site = get_default_site()
-    return ('https' if os.environ.get('HTTPS') == 'on' else 'http') + '://' + re.sub(r'^(https://|http//)', '', default_site.hostname)
+    return ('https' if os.environ.get('HTTPS') == 'on' else 'http') + '://' + re.sub(r'^(https://|http://)', '', default_site.hostname)
 
 
 def reverse_with_site_url(urlname, kwargs=None):

--- a/pages/models.py
+++ b/pages/models.py
@@ -1,3 +1,5 @@
+import re
+import os
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.core.models import Page
@@ -27,7 +29,15 @@ class StaticPage(Page):
         verbose_name_plural = _('Static Pages')
 
 
-class HomePage(MetadataPageMixin, Page):
+class _MetadataPageMixin(MetadataPageMixin):
+    def get_meta_url(self):
+        return ('https' if os.environ.get('HTTPS') == 'on' else 'http') + '://' + re.sub(r'^(https://|http://)', '', self.full_url)
+
+    class Meta:
+        abstract = True
+
+
+class HomePage(_MetadataPageMixin, Page):
     body = StreamField([
         ('full_width_image', FullWidthImageSectionBlock()),
         ('full_width_section', FullWidthSectionBlock()),


### PR DESCRIPTION
added missing colon in get_site_url, overridden get_meta_url for MetadataPageMixin so that og:url now follows https scheme