### PR TITLE
Add a check for permissions page to checkbox widget

### DIFF
--- a/newstream/templates/django/forms/widgets/checkbox_option.html
+++ b/newstream/templates/django/forms/widgets/checkbox_option.html
@@ -1,4 +1,6 @@
 <div class="mb-1 widget_checkboxinput flex items-center">
     {% include "django/forms/widgets/input.html" %}
-    <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}" {% endif %}>{{ widget.label }}</label>
+    {% ifnotequal widget.name 'permissions' %}
+        <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}" {% endif %}>{{ widget.label }}</label>
+    {% endifnotequal %}
 </div>


### PR DESCRIPTION
Removes the labels in the permission page so that the UI looks better.