### PR TITLE
NWST-327: Add django-extensions

### DIFF
--- a/django-app/requirements.txt
+++ b/django-app/requirements.txt
@@ -11,6 +11,7 @@ django-allauth==0.44.0
 django-allauth-2fa==0.8
 django-cogwheels==0.3
 django-environ==0.4.5
+django-extensions==3.1.3
 django-filter==2.4.0
 django-i18nfield==1.9.1
 django-modelcluster==5.1


### PR DESCRIPTION
This is to add capability to run "python manage.py reset_db" in the cloud run job.