### PR TITLE
NWST-321 - add login signup and forgot password tests

### DIFF
--- a/django-app/newstream/templates/header.html
+++ b/django-app/newstream/templates/header.html
@@ -29,11 +29,11 @@
                 <div class="user-dropdown-menu dropdown-menu-popup flex flex-col items-stretch">
                     <a href="{% url 'personal-info' %}">{% trans 'Profile Settings' %}</a>
                     <a href="{% url 'donations:my-onetime-donations' %}">{% trans 'My Donations' %}</a>
-                    <a href="{% url 'account_logout' %}">{% trans 'Logout' %}</a>
+                    <a id="header-logout" href="{% url 'account_logout' %}">{% trans 'Logout' %}</a>
                 </div>
             </div>
             {% else %}
-            <a href="{% url 'account_login' %}{{ request.path|next_path_filter }}" class="mr-16 menu-item">{% trans 'Sign in' %}</a>
+            <a id="header-sign-in" href="{% url 'account_login' %}{{ request.path|next_path_filter }}" class="mr-16 menu-item">{% trans 'Sign in' %}</a>
             {% endif %}
             <a href="{% url 'donations:donate'%}" class="menu-item nav-donate-btn">{% trans 'Donate' %}</a>
             <div class="multilang-dropdown-div ml-6 hidden lg:hidden items-center dropdown-div-wrapper">

--- a/notebooks/components.py
+++ b/notebooks/components.py
@@ -53,6 +53,15 @@ class Input:
         self.element.clear()
 
 
+class Label:
+    xpath = 'label'
+    def __init__(self, driver, identifier):
+        self.element = get_element_by_identifier(driver, self.xpath, identifier)
+
+    def click(self):
+        self.element.click()
+
+
 class Application:
     def __init__(self, driver):
         self.driver = driver
@@ -70,6 +79,9 @@ class Application:
     
     def input(self, identifier):
         return Input(self.driver, identifier)
+    
+    def label(self, identifier):
+        return Label(self.driver, identifier)
     
     #### Methods ####
     

--- a/notebooks/selenium/Forgot Password.py
+++ b/notebooks/selenium/Forgot Password.py
@@ -24,7 +24,7 @@ from diffractive.selenium import wait_element, ScreenGrabber, get_webdriver, not
 from diffractive.selenium.visualisation import gallery
 
 from components import Application
-from utils import get_email_count, wait_for_email, get_emails, get_email_by_email_subject, clear_all_emails
+from utils import get_email_count, wait_for_email, get_emails, get_link_by_email_subject_and_regex, clear_all_emails
 # +
 clear_all_emails()
 
@@ -66,7 +66,7 @@ assert email_recipient == email, \
 
 subject = "Please Reset Your Password"
 reg_str = "(?P<url>http://app.newstream.local:8000/en/accounts/password/reset/key/[^/]*/)"
-url = get_email_by_email_subject(subject, reg_str)
+url = get_link_by_email_subject_and_regex(subject, reg_str)
 driver.get(url)
 grabber.capture_screen('password_reset', 'Reset password form')
 
@@ -102,7 +102,7 @@ app.button('Submit').click()
 wait_for_email(email_count)
 subject = "Please Reset Your Password"
 reg_str = "(?P<url>http://app.newstream.local:8000/en/accounts/password/reset/key/[^/]*/)"
-url = get_email_by_email_subject(subject, reg_str)
+url = get_link_by_email_subject_and_regex(subject, reg_str)
 driver.get(url)
 app.input('id_password1').fill(old_pwd)
 app.input('id_password2').fill(old_pwd)

--- a/notebooks/selenium/Forgot Password.py
+++ b/notebooks/selenium/Forgot Password.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:light
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.11.4
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# +
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait, Select
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import NoSuchElementException
+
+from diffractive.selenium import wait_element, ScreenGrabber, get_webdriver, notebook_root
+from diffractive.selenium.visualisation import gallery
+
+from components import Application
+from utils import get_email_count, wait_for_email, get_emails, get_email_by_email_subject, clear_all_emails
+# +
+clear_all_emails()
+
+email = 'david.donor@diffractive.io'
+new_pwd = 'strongpwd'
+old_pwd = 'david.donor'
+email_count = get_email_count()
+# -
+
+driver = get_webdriver('portal')
+grabber = ScreenGrabber(driver)
+app = Application(driver)
+
+app.go()
+grabber.capture_screen('home_page', 'Home')
+
+
+app.link("header-sign-in").click()
+grabber.capture_screen('login_screen', 'Login')
+
+
+app.link('Forgot Password?').click()
+grabber.capture_screen('forgot_password', 'Forgot Password')
+
+app.input('id_email').fill(email)
+app.button('Submit').click()
+grabber.capture_screen('email_sent', 'Forgot password email sent')
+
+# +
+wait_for_email(email_count)
+email_content = get_emails()[0]
+email_title = email_content['Content']['Headers']['Subject'][0]
+email_recipient = email_content['Content']['Headers']['To'][0]
+
+assert email_title == 'Please Reset Your Password', f'Unexpected e-mail found: {email_title}'
+assert email_recipient == email, \
+    f"Unexpected e-mail recipient {email_recipient}, expected: {email}"
+# -
+
+subject = "Please Reset Your Password"
+reg_str = "(?P<url>http://app.newstream.local:8000/en/accounts/password/reset/key/[^/]*/)"
+url = get_email_by_email_subject(subject, reg_str)
+driver.get(url)
+grabber.capture_screen('password_reset', 'Reset password form')
+
+app.input('id_password1').fill(new_pwd)
+app.input('id_password2').fill(new_pwd)
+app.button('Submit').click()
+grabber.capture_screen('password_reset_success', 'Password has been reset')
+
+# ## Test
+
+app.link("header-sign-in").click()
+grabber.capture_screen('login_screen', 'Login')
+
+app.input('id_login').fill(email)
+app.input('id_password').fill(new_pwd)
+grabber.capture_screen('filled_login_form', 'Filled Login Form')
+
+app.button('Login').click()
+grabber.capture_screen('logged_in', 'Logged in')
+
+# ## Reset info back to default
+
+# Logout
+app.label('dropdown-toggle-checkbox').click()
+app.link("header-logout").click()
+grabber.capture_screen('logged_out', 'Logged out')
+
+app.link("header-sign-in").click()
+app.link('Forgot Password?').click()
+app.input('id_email').fill(email)
+app.button('Submit').click()
+
+wait_for_email(email_count)
+subject = "Please Reset Your Password"
+reg_str = "(?P<url>http://app.newstream.local:8000/en/accounts/password/reset/key/[^/]*/)"
+url = get_email_by_email_subject(subject, reg_str)
+driver.get(url)
+app.input('id_password1').fill(old_pwd)
+app.input('id_password2').fill(old_pwd)
+app.button('Submit').click()
+grabber.capture_screen('reset_to_default', 'Reset to default')
+
+gallery(zip(grabber.screens.values(), grabber.captions.values()), row_height="300px")

--- a/notebooks/selenium/User Login.py
+++ b/notebooks/selenium/User Login.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:light
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.11.4
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# +
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait, Select
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import NoSuchElementException
+
+from diffractive.selenium import wait_element, ScreenGrabber, get_webdriver, notebook_root
+from diffractive.selenium.visualisation import gallery
+
+from components import Application
+# -
+
+email = 'david.donor@diffractive.io'
+password = 'david.donor'
+
+driver = get_webdriver('portal')
+grabber = ScreenGrabber(driver)
+app = Application(driver)
+
+app.go()
+grabber.capture_screen('home_page', 'Home')
+
+
+app.link("header-sign-in").click()
+grabber.capture_screen('login_screen', 'Login')
+
+app.input('id_login').fill(email)
+app.input('id_password').fill(password)
+grabber.capture_screen('filled_login_form', 'Filled Login Form')
+
+app.button('Login').click()
+grabber.capture_screen('logged_in', 'Logged in')
+
+# ## Logout flow
+
+app.label('dropdown-toggle-checkbox').click()
+grabber.capture_screen('user_menu_expanded', 'Expanded user menu')
+
+app.link("header-logout").click()
+grabber.capture_screen('logged_out', 'Logged out')
+
+gallery(zip(grabber.screens.values(), grabber.captions.values()), row_height="300px")

--- a/notebooks/selenium/User Sign Up.py
+++ b/notebooks/selenium/User Sign Up.py
@@ -24,11 +24,12 @@ from diffractive.selenium import wait_element, ScreenGrabber, get_webdriver, not
 from diffractive.selenium.visualisation import gallery
 
 from components import Application
-from utils import get_email_count, wait_for_email, get_emails
+from utils import get_email_count, wait_for_email, get_emails, get_email_by_email_subject, clear_all_emails
 
 import secrets
 
 # +
+clear_all_emails()
 randstr = secrets.token_hex(6).upper()
 
 email = f'test_user{randstr}@newstream.com'
@@ -78,12 +79,21 @@ email_titles = [admin_email, user_email]
 for email_content in emails:
     email_title = email_content['Content']['Headers']['Subject'][0]
     email_recipient = email_content['Content']['Headers']['To'][0]
-    
+
     assert email_title in email_titles, f'Unexpected e-mail found: {email_title}'
     if email_title == user_email:
         assert email_recipient == email, \
             f"Unexpected e-mail recipient {email_recipient}, expected: {email}"
     email_titles.remove(email_title)
 # -
+
+subject = "Please Confirm Your Email Address"
+reg_str = "(?P<url>http://app.newstream.local:8000/en/accounts/confirm-email/[^/]*/)"
+url = get_email_by_email_subject(subject, reg_str)
+driver.get(url)
+grabber.capture_screen('email_confirm', 'Confirm email')
+
+app.button('Confirm').click()
+grabber.capture_screen('email_confirmed', 'Email confirmed')
 
 gallery(zip(grabber.screens.values(), grabber.captions.values()), row_height="300px")

--- a/notebooks/selenium/User Sign Up.py
+++ b/notebooks/selenium/User Sign Up.py
@@ -24,7 +24,7 @@ from diffractive.selenium import wait_element, ScreenGrabber, get_webdriver, not
 from diffractive.selenium.visualisation import gallery
 
 from components import Application
-from utils import get_email_count, wait_for_email, get_emails, get_email_by_email_subject, clear_all_emails
+from utils import get_email_count, wait_for_email, get_emails, get_link_by_email_subject_and_regex, clear_all_emails
 
 import secrets
 
@@ -99,7 +99,7 @@ for email_content in emails:
 
 subject = "Please Confirm Your Email Address"
 reg_str = "(?P<url>http://app.newstream.local:8000/en/accounts/confirm-email/[^/]*/)"
-url = get_email_by_email_subject(subject, reg_str)
+url = get_link_by_email_subject_and_regex(subject, reg_str)
 driver.get(url)
 grabber.capture_screen('email_confirm', 'Confirm email')
 

--- a/notebooks/selenium/User Sign Up.py
+++ b/notebooks/selenium/User Sign Up.py
@@ -32,6 +32,7 @@ import secrets
 clear_all_emails()
 randstr = secrets.token_hex(6).upper()
 
+used_email = 'david.donor@diffractive.io'
 email = f'test_user{randstr}@newstream.com'
 first_name = 'Test'
 last_name = 'User'
@@ -57,12 +58,21 @@ grabber.capture_screen('register_login', 'Register or login page')
 app.link('Continue with Email Sign up').click()
 grabber.capture_screen('sign_up', 'Sign up form')
 
-app.input('id_email').fill(email)
+app.input('id_email').fill(used_email)
 app.input('id_first_name').fill(first_name)
 app.input('id_last_name').fill(last_name)
 app.input('id_password1').fill(password)
 app.input('id_password2').fill(password)
 grabber.capture_screen('filled_form', 'Filled signup form')
+
+app.button('Continue').click()
+grabber.capture_screen('failed_sign_up', 'Email already taken')
+
+app.input('id_email').clear()
+app.input('id_email').fill(email)
+app.input('id_password1').fill(password)
+app.input('id_password2').fill(password)
+grabber.capture_screen('correct_filled_form', 'Correct Filled signup form')
 
 app.button('Continue').click()
 grabber.capture_screen('signed_up', 'Successfully signed up')

--- a/notebooks/utils.py
+++ b/notebooks/utils.py
@@ -4,6 +4,7 @@ import requests
 import quopri
 import base64
 import time
+import re
 
 def get_element_by_identifier(driver, element, identifier):
     """
@@ -20,8 +21,14 @@ def get_element_by_identifier(driver, element, identifier):
         return driver.find_element(By.XPATH, f'//{element}[@name="{identifier}"]')
     except NoSuchElementException:
         pass
+    # For links
     try:
         return driver.find_element(By.XPATH, f'//{element}[contains(@href, "{identifier}")]')
+    except NoSuchElementException:
+        pass
+    # For labels
+    try:
+        return driver.find_element(By.XPATH, f'//{element}[@for="{identifier}"]')
     except NoSuchElementException:
         pass
 
@@ -43,7 +50,7 @@ def get_email_count():
     response = requests.get("http://mailhog.newstream.local:8025/api/v2/messages")
     response.encoding = 'utf-8'
     response = response.json()
-    
+
     return len(response['items'])
 
 
@@ -75,6 +82,43 @@ def get_emails(index=0, count=1):
 
     if not response['items']:
         return ''
-    
+
     return response['items'][index:index+count]
 
+def get_email_by_email_subject(subject, reg_str):
+    """
+    Get url from email given subjeect, and reg_str of what the expected link format should be
+    """
+    json_object = requests.get(
+        "http://mailhog.newstream.local:8025/api/v1/messages"
+    )
+    response_json = json_object.json()
+
+
+    for email in response_json:
+        if email['Content']['Headers']['Subject'][0] == subject:
+            body = email['Content']['Body']
+            link_re = re.compile(reg_str)
+            url = link_re.search(body).groups()[0]
+            clear_email(email['ID'])
+            return url
+
+    return ''
+
+
+def clear_email(message_id):
+    """
+    Delete email
+    """
+    json_object = requests.delete(
+        "http://mailhog.newstream.local:8025/api/v1/messages/%s" % (message_id)
+    )
+
+
+def clear_all_emails():
+    """
+    Delete all emails to clear up the email
+    """
+    json_object = requests.delete(
+        'http://mailhog.newstream.local:8025/api/v1/messages'
+    )

--- a/notebooks/utils.py
+++ b/notebooks/utils.py
@@ -85,7 +85,7 @@ def get_emails(index=0, count=1):
 
     return response['items'][index:index+count]
 
-def get_email_by_email_subject(subject, reg_str):
+def get_link_by_email_subject_and_regex(subject, reg_str):
     """
     Get url from email given subjeect, and reg_str of what the expected link format should be
     """


### PR DESCRIPTION
Uses some of the same code that was introduced in #183 
added ids to sign in and logout boxes so they can be distinguished from the mobile version of the site