### PR TITLE
NWST-414: Fix snyk scan

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -24,6 +24,13 @@ ignore:
           only admins have access to the vulnerable functions
         expires: 2023-12-06T03:41:02.060Z
         created: 2023-07-28T03:41:02.078Z
+  SNYK-PYTHON-PILLOW-6043904:
+    - '*':
+        reason: >
+          Can't be upgraded without upgrading wagtail. Also can be ignored because
+          only admins have access to the vulnerable functions
+        expires: 2023-12-06T03:41:02.060Z
+        created: 2023-11-06T04:22:02.078Z
   SNYK-DEBIAN12-NGHTTP2-5953379:
     - '*':
         reason: >
@@ -34,7 +41,7 @@ ignore:
   SNYK-DEBIAN12-ZLIB-6008963:
     - '*':
         reason: No fix available. We don't seem to be impacted by this.
-        expires: 2023-11-04T00:00:00.000Z
+        expires: 2023-11-11T00:00:00.000Z
         created: 2023-10-25T19:27:37.731Z
 
 patch:

--- a/django-app/requirements.txt
+++ b/django-app/requirements.txt
@@ -6,7 +6,7 @@ cffi==1.16.0
 chardet==4.0.0
 cryptography==41.0.5
 defusedxml==0.7.1
-Django==3.2.22
+Django==3.2.23
 django-allauth==0.54.0
 django-allauth-2fa==0.8
 django-cogwheels==0.3


### PR DESCRIPTION
- added snyk exception for pillow upgrade
- updated minor version of django
- postponed expiration for debian zlib vulnerability